### PR TITLE
Fix busy slot times to respect local timezone

### DIFF
--- a/new/sesja.html
+++ b/new/sesja.html
@@ -371,8 +371,10 @@
 
 
             async function fetchGoogleBusySlotsForDate(date, duration) {
-                const start = new Date(`${date}T00:00:00Z`).toISOString();
-                const end = new Date(`${date}T23:59:59Z`).toISOString();
+                // Use local timezone for the selected day so Google receives the
+                // correct UTC interval
+                const start = new Date(`${date}T00:00:00`).toISOString();
+                const end = new Date(`${date}T23:59:59`).toISOString();
                 logDebug(`Zapytanie freeBusy dla ${date}, od ${start} do ${end}`);
 
                 try {
@@ -401,7 +403,8 @@
                         const e = new Date(slot.end);
                         const cursor = new Date(s);
                         while (cursor < e) {
-                            result.push(cursor.toISOString().substring(11, 16));
+                            result.push(cursor
+                                .toLocaleTimeString('pl-PL', { hour: '2-digit', minute: '2-digit', hour12: false }));
                             cursor.setMinutes(cursor.getMinutes() + duration);
                         }
                     });

--- a/sesja.html
+++ b/sesja.html
@@ -371,8 +371,9 @@
 
 
             async function fetchGoogleBusySlotsForDate(date, duration) {
-                const start = new Date(`${date}T00:00:00Z`).toISOString();
-                const end = new Date(`${date}T23:59:59Z`).toISOString();
+                // Use local timezone to ensure correct UTC range for Google API
+                const start = new Date(`${date}T00:00:00`).toISOString();
+                const end = new Date(`${date}T23:59:59`).toISOString();
                 logDebug(`Zapytanie freeBusy dla ${date}, od ${start} do ${end}`);
 
                 try {
@@ -401,7 +402,8 @@
                         const e = new Date(slot.end);
                         const cursor = new Date(s);
                         while (cursor < e) {
-                            result.push(cursor.toISOString().substring(11, 16));
+                            result.push(cursor
+                                .toLocaleTimeString('pl-PL', { hour: '2-digit', minute: '2-digit', hour12: false }));
                             cursor.setMinutes(cursor.getMinutes() + duration);
                         }
                     });


### PR DESCRIPTION
## Summary
- handle timezone correctly when querying Google Calendar
- display busy slots using local time instead of UTC

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6864475b06a48321867350c55875c3eb