### PR TITLE
Fix busy slot logic and add full day option

### DIFF
--- a/sesja.html
+++ b/sesja.html
@@ -132,6 +132,7 @@
                         <option value="onboarding">Onboarding</option>
                         <option value="sesja umówiona">Sesja umówiona</option>
                         <option value="kup sesję" selected>Kup sesję</option>
+                        <option value="full day">Full day</option>
                     </select>
 
                 </div>
@@ -337,7 +338,14 @@
 
             async function fetchBusySlots(date, duration) {
                 const data = await apiRequest(`backend/calendar.php?action=busy&date=${date}&duration=${duration}&return=/sesja.html`);
-                return data ? data.busy : [];
+                const busy = data ? data.busy : [];
+                const result = new Set();
+                busy.forEach(time => {
+                    const dt = new Date(`${date}T${time}:00`);
+                    dt.setMinutes(Math.floor(dt.getMinutes() / duration) * duration, 0, 0);
+                    result.add(dt.toLocaleTimeString('pl-PL', { hour: '2-digit', minute: '2-digit', hour12: false }));
+                });
+                return Array.from(result);
             }
 
             async function showTimes() {
@@ -350,11 +358,36 @@
                 const dateLabel = parsed.toLocaleDateString("pl-PL", {
                     weekday: "long", year: "numeric", month: "long", day: "numeric"
                 });
-                timeLabel.textContent = `Wybierz godzinę (${dateLabel})`;
 
                 const duration = meetingType === "onboarding" ? 30 : 60;
-                const slots = [];
+                const busySlots = await fetchBusySlots(selectedDate, duration);
+                logDebug(`Zajęte sloty: ${busySlots.join(', ') || 'brak'}`);
 
+                if (meetingType === "full day") {
+                    timeLabel.textContent = `Sprawdź dostępność (${dateLabel})`;
+                    if (busySlots.length === 0) {
+                        const fullBtn = document.createElement("button");
+                        fullBtn.type = "button";
+                        fullBtn.textContent = "Full day";
+                        fullBtn.className = "border rounded px-3 py-2 text-sm transition hover:bg-accent hover:text-white";
+                        fullBtn.addEventListener("click", () => {
+                            selectedTime = "09:00";
+                            [...timeButtons.children].forEach(b => b.classList.remove("bg-accent", "text-white"));
+                            fullBtn.classList.add("bg-accent", "text-white");
+                        });
+                        timeButtons.appendChild(fullBtn);
+                    } else {
+                        const msg = document.createElement("div");
+                        msg.textContent = "Ten dzień jest częściowo zajęty.";
+                        msg.className = "col-span-3 text-center text-red-600";
+                        timeButtons.appendChild(msg);
+                    }
+                    return;
+                }
+
+                timeLabel.textContent = `Wybierz godzinę (${dateLabel})`;
+
+                const slots = [];
                 for (let h = 9; h <= 16; h++) {
                     for (let m = 0; m < 60; m += duration) {
                         const time = `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
@@ -363,9 +396,6 @@
                         if (end.getHours() < 17) slots.push(time);
                     }
                 }
-
-                const busySlots = await fetchBusySlots(selectedDate, duration);
-                logDebug(`Zajęte sloty: ${busySlots.join(', ') || 'brak'}`);
 
                 slots.forEach(time => {
                     const btn = document.createElement("button");
@@ -403,9 +433,17 @@
             }
 
             async function createCalendarEvent(email, meetingType) {
-                const startDateTime = new Date(`${selectedDate}T${selectedTime}:00`);
-                const endDateTime = new Date(startDateTime);
-                endDateTime.setMinutes(endDateTime.getMinutes() + (meetingType === "onboarding" ? 30 : 60));
+                let startDateTime;
+                let endDateTime;
+                if (meetingType === "full day") {
+                    startDateTime = new Date(`${selectedDate}T09:00:00`);
+                    endDateTime = new Date(`${selectedDate}T17:00:00`);
+                } else {
+                    startDateTime = new Date(`${selectedDate}T${selectedTime}:00`);
+                    endDateTime = new Date(startDateTime);
+                    const minutes = meetingType === "onboarding" ? 30 : 60;
+                    endDateTime.setMinutes(endDateTime.getMinutes() + minutes);
+                }
 
                 const payload = {
                     summary: `Spotkanie - ${meetingType}`,


### PR DESCRIPTION
## Summary
- fix busy slot deduplication in `sesja.html`
- add "Full day" meeting type
- allow booking the entire day if the date has no reservations

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_68644cda00608321919727874d2e2efe