### PR TITLE
Fix OAuth redirect URI

### DIFF
--- a/backend/calendar.php
+++ b/backend/calendar.php
@@ -11,7 +11,7 @@ use Google\Service\Calendar\FreeBusyRequest;
 // Configure Google Client
 $client = new Client();
 $client->setAuthConfig(__DIR__ . '/credentials.json');
-$client->setRedirectUri((isset($_SERVER['HTTPS']) ? 'https://' : 'http://') . $_SERVER['HTTP_HOST'] . $_SERVER['PHP_SELF']);
+$client->setRedirectUri('https://zientkowski.pl/backend/calendar.php');
 $client->addScope(Calendar::CALENDAR);
 $client->setAccessType('offline');
 


### PR DESCRIPTION
## Summary
- use fixed URL `https://zientkowski.pl/backend/calendar.php` for OAuth redirect

## Testing
- `php -l backend/calendar.php` *(fails: command not found)*
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686674f9f52483219dd0a65b2cce686b