### PR TITLE
Ensure cookies sent and handle non-JSON

### DIFF
--- a/sesja.html
+++ b/sesja.html
@@ -325,6 +325,7 @@
 
 
             async function apiRequest(url, options = {}) {
+                options.credentials = options.credentials || 'include';
                 const resp = await fetch(url, options);
                 if (resp.status === 401) {
                     const data = await resp.json();
@@ -333,7 +334,12 @@
                     }
                     return null;
                 }
-                return resp.json();
+                try {
+                    return await resp.json();
+                } catch (err) {
+                    console.error('Non-JSON response', err);
+                    return null;
+                }
             }
 
             async function fetchBusySlots(date, duration) {


### PR DESCRIPTION
## Summary
- default to using credentials when making API requests in `sesja.html`
- handle non-JSON responses from the API

## Testing
- `composer validate --no-check-publish` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_68669b2d0c208321ae0ee35e1f1fc823