### PR TITLE
Fix full day availability check

### DIFF
--- a/backend/calendar.php
+++ b/backend/calendar.php
@@ -63,7 +63,8 @@ if ($action === 'busy') {
         exit();
     }
     $timeMin = $date . 'T00:00:00Z';
-    $timeMax = $date . 'T15:30:59Z';
+    $fullDay = isset($_GET['fullDay']) && $_GET['fullDay'] == '1';
+    $timeMax = $fullDay ? $date . 'T23:59:59Z' : $date . 'T15:30:59Z';
     $req = new FreeBusyRequest([
         'timeMin' => $timeMin,
         'timeMax' => $timeMax,

--- a/sesja.html
+++ b/sesja.html
@@ -349,8 +349,9 @@
                 }
             }
 
-            async function fetchBusySlots(date, duration) {
-                const data = await apiRequest(`backend/calendar.php?action=busy&date=${date}&duration=${duration}&return=/sesja.html`);
+            async function fetchBusySlots(date, duration, fullDay = false) {
+                const fullParam = fullDay ? '&fullDay=1' : '';
+                const data = await apiRequest(`backend/calendar.php?action=busy&date=${date}&duration=${duration}${fullParam}&return=/sesja.html`);
                 const busy = data ? data.busy : [];
                 console.log(data);
                 const result = new Set();
@@ -374,7 +375,7 @@
                 });
 
                 const duration = meetingType === "onboarding" ? 30 : 60;
-                const busySlots = await fetchBusySlots(selectedDate, duration);
+                const busySlots = await fetchBusySlots(selectedDate, duration, meetingType === "full day");
                 logDebug(`Zajęte sloty: ${busySlots.join(', ') || 'brak'}`);
                 
 


### PR DESCRIPTION
## Summary
- adjust calendar backend so `full day` queries check the entire day
- allow sending a `fullDay` flag when checking busy slots in the booking page

## Testing
- `composer test` *(fails: `composer: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6866b5c2ca4c83218a18940c77d33d73