### PR TITLE
Fix busy slot retrieval

### DIFF
--- a/backend/calendar.php
+++ b/backend/calendar.php
@@ -71,13 +71,13 @@ if ($action === 'busy') {
         'items' => [['id' => 'primary']]
     ]);
     $res = $service->freebusy->query($req);
-    $busy = $res->getCalendars()['primary']['busy'] ?? [];
+    $busy = $res->getCalendars()['primary']->getBusy();
     $slots = [];
     foreach ($busy as $b) {
-        $start = new DateTime($b['start'], new DateTimeZone('UTC'));
+        $start = new DateTime($b->getStart(), new DateTimeZone('UTC'));
         $start->setTimezone(new DateTimeZone('Europe/Warsaw'));
 
-        $end = new DateTime($b['end'], new DateTimeZone('UTC'));
+        $end = new DateTime($b->getEnd(), new DateTimeZone('UTC'));
         $end->setTimezone(new DateTimeZone('Europe/Warsaw'));
 
         $cursor = clone $start;


### PR DESCRIPTION
## Summary
- update busy slot fetching for Google Calendar integration
- access TimePeriod objects correctly

## Testing
- `php -l backend/calendar.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68679916db8c8321ba400249077e380f