### PR TITLE
Improve calendar summary with emoji and email

### DIFF
--- a/sesja.html
+++ b/sesja.html
@@ -462,7 +462,7 @@
                 }
 
                 const payload = {
-                    summary: `Spotkanie - ${meetingType}`,
+                    meetingType,
                     start: startDateTime.toISOString(),
                     end: endDateTime.toISOString(),
                     attendees: email ? [email] : []


### PR DESCRIPTION
## Summary
- build calendar event title from meeting type and attendee email
- send meeting type via API instead of prebuilt summary

## Testing
- `php -l backend/calendar.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68679bd2fa1883219b671306bceb6793