### PR TITLE
Add calendar_title field and update event summary

### DIFF
--- a/backend/calendar.php
+++ b/backend/calendar.php
@@ -106,8 +106,9 @@ if ($action === 'create' && $_SERVER['REQUEST_METHOD'] === 'POST') {
     $key = strtolower($meetingType);
     $emoji = isset($meetingTypes[$key]['emoji']) ? $meetingTypes[$key]['emoji'] : '🗓️';
     $displayName = isset($meetingTypes[$key]['name']) ? $meetingTypes[$key]['name'] : ucfirst($meetingType);
+    $calendarTitle = isset($meetingTypes[$key]['calendar_title']) ? $meetingTypes[$key]['calendar_title'] : $displayName;
 
-    $summary = trim(sprintf('%s %s%s', $emoji, $displayName, $email ? ' - ' . $email : ''));
+    $summary = trim(sprintf('%s %s%s', $emoji, $calendarTitle, $email ? ' - ' . $email : ''));
 
     $start = new DateTime($data['start']);
     $end = new DateTime($data['end']);

--- a/config.json
+++ b/config.json
@@ -3,24 +3,28 @@
   "meetingTypes": {
     "onboarding": {
       "name": "Onboarding",
+      "calendar_title": "Onboarding",
       "emoji": "🎉",
       "duration": 30,
       "paid": false
     },
     "sesja umówiona": {
       "name": "Sesja umówiona",
+      "calendar_title": "Sesja umówiona",
       "emoji": "🤝",
       "duration": 60,
       "paid": false
     },
     "kup sesję": {
       "name": "Kup sesję",
+      "calendar_title": "Sesja płatna",
       "emoji": "💸",
       "duration": 60,
       "paid": true
     },
     "full day": {
       "name": "Full day",
+      "calendar_title": "Full day",
       "emoji": "📅",
       "duration": "full",
       "paid": true


### PR DESCRIPTION
## Summary
- expand config to include `calendar_title` for each meeting type
- use `calendar_title` when creating Google Calendar events

## Testing
- `jq '.' config.json`
- `php -l backend/calendar.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867a387bdcc83219f1361a60f81ae59