### PR TITLE
Load meeting types dynamically

### DIFF
--- a/sesja.html
+++ b/sesja.html
@@ -128,11 +128,8 @@
             <form id="meetingForm" class="space-y-6">
                 <div>
                     <label class="block mb-2 font-medium">Typ spotkania</label>
-                    <select class="w-full border border-gray-300 rounded-lg p-3" required>
-                        <option value="onboarding">Onboarding</option>
-                        <option value="sesja umówiona">Sesja umówiona</option>
-                        <option value="kup sesję" selected>Kup sesję</option>
-                        <option value="full day">Full day</option>
+                    <select id="meeting-type" class="w-full border border-gray-300 rounded-lg p-3" required>
+                        <option disabled selected>Ładowanie…</option>
                     </select>
 
                 </div>
@@ -223,7 +220,7 @@
             const debugVisible = config.debugBoxVisible !== false;
             const meetingTypesCfg = config.meetingTypes || {};
 
-            const select = document.querySelector('select');
+            const select = document.getElementById('meeting-type');
             select.innerHTML = '';
             Object.entries(meetingTypesCfg).forEach(([key, mt]) => {
                 const opt = document.createElement('option');
@@ -514,7 +511,7 @@
                 }
 
                 const email = form.querySelector("input[type='email']").value;
-                const meetingType = form.querySelector("select").value;
+                const meetingType = document.getElementById('meeting-type').value;
                 await createCalendarEvent(email, meetingType);
                 alert(`Rezerwacja przyjęta:
 🗓️ Data: ${selectedDate}
@@ -523,7 +520,7 @@
 📌 Typ: ${meetingType}`);
             });
 
-            document.querySelector("select").addEventListener("change", e => {
+            document.getElementById('meeting-type').addEventListener("change", e => {
                 meetingType = e.target.value;
                 if (selectedDate) showTimes(); // odśwież sloty jeśli dzień już wybrany
             });


### PR DESCRIPTION
## Summary
- load meeting types for the meeting form from `config.json`
- remove hardcoded options

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6867a5259e548321becd4fc6afdd79de