### PR TITLE
Add PayPal checkout integration for paid meetings

### DIFF
--- a/sesja.html
+++ b/sesja.html
@@ -166,6 +166,7 @@
                 <button type="submit" class="w-full bg-accent text-white py-3 px-6 hover:bg-dark transition fixed bottom-0 left-0 right-0 z-50 rounded-none md:static md:rounded-lg">
                     Zarezerwuj spotkanie
                 </button>
+                <div id="paypal-button-container" class="hidden mt-4"></div>
             </form>
         </div>
     </section>
@@ -206,6 +207,7 @@
     <script defer src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/ScrollTrigger.min.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/ScrollToPlugin.min.js"></script>
     <script defer src="./assets/js/animations.js"></script>
+    <script src="https://www.paypal.com/sdk/js?client-id=sb&currency=PLN"></script>
 
     <script>
         document.addEventListener("DOMContentLoaded", async () => {
@@ -518,12 +520,42 @@
 
                 const email = form.querySelector("input[type='email']").value;
                 const meetingType = document.getElementById('meeting-type').value;
-                await createCalendarEvent(email, meetingType);
-                alert(`Rezerwacja przyjęta:
-🗓️ Data: ${selectedDate}
-🕒 Godzina: ${selectedTime}
-📧 Email: ${email}
-📌 Typ: ${meetingType}`);
+                const mtConf = meetingTypesCfg[meetingType] || {};
+
+                const successMsg = `Rezerwacja przyjęta:\n🗓️ Data: ${selectedDate}\n🕒 Godzina: ${selectedTime}\n📧 Email: ${email}\n📌 Typ: ${meetingType}`;
+
+                async function finalize() {
+                    await createCalendarEvent(email, meetingType);
+                    alert(successMsg);
+                }
+
+                if (mtConf.paid) {
+                    const container = document.getElementById('paypal-button-container');
+                    container.classList.remove('hidden');
+                    container.innerHTML = '';
+                    paypal.Buttons({
+                        createOrder: (data, actions) => {
+                            return actions.order.create({
+                                purchase_units: [{
+                                    amount: { value: mtConf.amount || '1.00' }
+                                }]
+                            });
+                        },
+                        onApprove: (data, actions) => {
+                            return actions.order.capture().then(finalize).catch(err => {
+                                console.error(err);
+                                alert('Błąd płatności');
+                            });
+                        },
+                        onCancel: () => alert('Płatność anulowana'),
+                        onError: err => {
+                            console.error(err);
+                            alert('Błąd płatności');
+                        }
+                    }).render('#paypal-button-container');
+                } else {
+                    await finalize();
+                }
             });
 
             document.getElementById('meeting-type').addEventListener("change", e => {


### PR DESCRIPTION
## Summary
- embed PayPal JS SDK
- add hidden container for PayPal button
- detect paid meeting type and launch PayPal checkout
- create calendar event after payment success

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6867ab5dde8883218d2b6b546c9c745d