### PR TITLE
Add PayPal configuration

### DIFF
--- a/config.html
+++ b/config.html
@@ -78,6 +78,17 @@
             <span>Pokaż debug box</span>
         </label>
 
+        <div class="space-y-2">
+            <label class="block">
+                <span class="block mb-1">PayPal Client ID</span>
+                <input type="text" id="paypalClientId" class="border rounded px-2 py-1 w-full">
+            </label>
+            <label class="block">
+                <span class="block mb-1">Waluta PayPal</span>
+                <input type="text" id="paypalCurrency" class="border rounded px-2 py-1 w-full">
+            </label>
+        </div>
+
         <div id="meetings" class="space-y-4"></div>
 
         <div class="flex space-x-2">
@@ -109,6 +120,8 @@
     async function loadConfig() {
         const cfg = await fetch('config.json').then(r => r.json()).catch(() => ({}));
         document.getElementById('debugVisible').checked = cfg.debugBoxVisible !== false;
+        document.getElementById('paypalClientId').value = cfg.paypal?.clientId || '';
+        document.getElementById('paypalCurrency').value = cfg.paypal?.currency || '';
         const mt = cfg.meetingTypes || {};
         Object.entries(mt).forEach(([k, v]) => addMeeting(k, v));
     }
@@ -143,6 +156,10 @@
         });
         const cfg = {
             debugBoxVisible: document.getElementById('debugVisible').checked,
+            paypal: {
+                clientId: document.getElementById('paypalClientId').value.trim(),
+                currency: document.getElementById('paypalCurrency').value.trim()
+            },
             meetingTypes: mt
         };
         const res = await fetch('backend/save_config.php', {

--- a/config.json
+++ b/config.json
@@ -1,5 +1,9 @@
 {
     "debugBoxVisible": false,
+    "paypal": {
+        "clientId": "sb",
+        "currency": "PLN"
+    },
     "meetingTypes": {
         "onboarding": {
             "name": "Onboarding",

--- a/sesja.html
+++ b/sesja.html
@@ -207,7 +207,7 @@
     <script defer src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/ScrollTrigger.min.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/ScrollToPlugin.min.js"></script>
     <script defer src="./assets/js/animations.js"></script>
-    <script src="https://www.paypal.com/sdk/js?client-id=sb&currency=PLN"></script>
+
 
     <script>
         document.addEventListener("DOMContentLoaded", async () => {
@@ -222,6 +222,11 @@
             const config = await fetch('config.json').then(r => r.json()).catch(() => ({}));
             const debugVisible = config.debugBoxVisible !== false;
             const meetingTypesCfg = config.meetingTypes || {};
+
+            const paypalCfg = config.paypal || {};
+            const paypalScript = document.createElement('script');
+            paypalScript.src = `https://www.paypal.com/sdk/js?client-id=${paypalCfg.clientId || 'sb'}&currency=${paypalCfg.currency || 'PLN'}`;
+            document.head.appendChild(paypalScript);
 
             const select = document.querySelector('select');
             const desc = document.getElementById('meeting-desc');


### PR DESCRIPTION
## Summary
- extend config.json with PayPal options
- allow editing PayPal client and currency on config page
- load PayPal script dynamically in the session page using the configured values

## Testing
- `php -l backend/paypal.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867ba08897c8321b0989804987c21cf