### PR TITLE
Add price field for meeting types

### DIFF
--- a/config.html
+++ b/config.html
@@ -108,6 +108,7 @@
             <input type="text" class="calendar_title border rounded px-2 py-1 w-full" placeholder="tytuł w kalendarzu">
             <input type="text" class="emoji border rounded px-2 py-1 w-full" placeholder="emoji">
             <input type="text" class="duration border rounded px-2 py-1 w-full" placeholder="czas trwania">
+            <input type="text" class="amount border rounded px-2 py-1 w-full" placeholder="cena">
             <textarea class="description border rounded px-2 py-1 w-full" placeholder="opis"></textarea>
             <label class="flex items-center space-x-2">
                 <input type="checkbox" class="paid">
@@ -134,6 +135,7 @@
         el.querySelector('.calendar_title').value = data.calendar_title || '';
         el.querySelector('.emoji').value = data.emoji || '';
         el.querySelector('.duration').value = data.duration || '';
+        el.querySelector('.amount').value = data.amount || '';
         el.querySelector('.description').value = data.description || '';
         el.querySelector('.paid').checked = !!data.paid;
         tmpl.querySelector('.remove').onclick = () => el.remove();
@@ -150,6 +152,7 @@
                 calendar_title: el.querySelector('.calendar_title').value,
                 emoji: el.querySelector('.emoji').value,
                 duration: el.querySelector('.duration').value,
+                amount: el.querySelector('.amount').value,
                 description: el.querySelector('.description').value,
                 paid: el.querySelector('.paid').checked
             };

--- a/config.json
+++ b/config.json
@@ -10,6 +10,7 @@
             "calendar_title": "Onboarding",
             "emoji": "🎉",
             "duration": "10",
+            "amount": "0",
             "description": "Krótka, 15minutowa sesja, podczas której omówimy zasady współpracy lub przedyskutujemy ustalony temat.",
             "paid": false
         },
@@ -18,6 +19,7 @@
             "calendar_title": "Sesja umówiona",
             "emoji": "🤝",
             "duration": "60",
+            "amount": "0",
             "description": "Jeśli jesteś w procesie współpracy ze mną, wybierz tę opcję - i pracujemy! :)",
             "paid": false
         },
@@ -26,6 +28,7 @@
             "calendar_title": "Sesja płatna",
             "emoji": "💸",
             "duration": "60",
+            "amount": "600.00",
             "description": "Jeśli chcesz od razu rozpocząć współpracę, wybierz tą opcję. System poprosi Cię o opłatę przed rezerwacją terminu.",
             "paid": true
         },
@@ -34,6 +37,7 @@
             "calendar_title": "Full day",
             "emoji": "📅",
             "duration": "full",
+            "amount": "0",
             "description": "Jeśli chcesz zarezerwować termin całodniowy (warsztaty, przemówienie...), wybierz tę opcję, zarezerwuj termin i skontaktuj się ze mną.",
             "paid": false
         },
@@ -42,6 +46,7 @@
             "calendar_title": "Warsztaty online",
             "emoji": "",
             "duration": "90",
+            "amount": "0",
             "description": "Warsztaty online trwają 4h. Jeśli je u mnie kupiłeś, rezerwuj termin!",
             "paid": false
         }

--- a/sesja.html
+++ b/sesja.html
@@ -132,6 +132,8 @@
                         <option disabled selected>Ładowanie…</option>
                     </select>
                     <p id="meeting-desc" class="mt-2 text-sm"></p>
+                    <p id="meeting-duration" class="text-sm text-gray-600"></p>
+                    <p id="meeting-price" class="text-sm text-gray-600"></p>
 
                 </div>
 
@@ -230,6 +232,8 @@
 
             const select = document.querySelector('select');
             const desc = document.getElementById('meeting-desc');
+            const durationEl = document.getElementById('meeting-duration');
+            const priceEl = document.getElementById('meeting-price');
 
             select.innerHTML = '';
             Object.entries(meetingTypesCfg).forEach(([key, mt]) => {
@@ -242,6 +246,18 @@
             select.value = defaultType;
             if (desc) {
                 desc.textContent = meetingTypesCfg[defaultType]?.description || '';
+            }
+            if (durationEl) {
+                const dur = meetingTypesCfg[defaultType]?.duration;
+                if (dur) {
+                    durationEl.textContent = dur === 'full' ? 'Czas trwania: cały dzień' : `Czas trwania: ${dur} min`;
+                } else {
+                    durationEl.textContent = '';
+                }
+            }
+            if (priceEl) {
+                const mt = meetingTypesCfg[defaultType] || {};
+                priceEl.textContent = mt.paid ? `Cena: ${mt.amount} PLN` : '';
             }
 
             let debugBox = null;
@@ -574,6 +590,18 @@
                 meetingType = e.target.value;
                 if (desc) {
                     desc.textContent = meetingTypesCfg[meetingType]?.description || '';
+                }
+                if (durationEl) {
+                    const dur = meetingTypesCfg[meetingType]?.duration;
+                    if (dur) {
+                        durationEl.textContent = dur === 'full' ? 'Czas trwania: cały dzień' : `Czas trwania: ${dur} min`;
+                    } else {
+                        durationEl.textContent = '';
+                    }
+                }
+                if (priceEl) {
+                    const mt = meetingTypesCfg[meetingType] || {};
+                    priceEl.textContent = mt.paid ? `Cena: ${mt.amount} PLN` : '';
                 }
                 if (selectedDate) showTimes(); // odśwież sloty jeśli dzień już wybrany
             });


### PR DESCRIPTION
## Summary
- include `amount` in `config.json` for each meeting type
- extend configuration editor with price input
- show meeting duration and price on the session booking page

## Testing
- `php -l backend/save_config.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6867bb14a7988321a259c885f70f49f7