### PR TITLE
Edit PayPal config from config.html

### DIFF
--- a/backend/paypal.php
+++ b/backend/paypal.php
@@ -2,9 +2,11 @@
 header('Content-Type: application/json');
 $action = $_GET['action'] ?? '';
 
-$clientId = getenv('PAYPAL_CLIENT_ID');
-$secret = getenv('PAYPAL_SECRET');
-$baseUrl = getenv('PAYPAL_BASE_URL') ?: 'https://api-m.sandbox.paypal.com';
+$cfgPath = dirname(__DIR__) . '/config.json';
+$cfg = is_file($cfgPath) ? json_decode(file_get_contents($cfgPath), true) : [];
+$clientId = $cfg['paypal']['clientId'] ?? '';
+$secret   = $cfg['paypal']['secret'] ?? '';
+$baseUrl  = $cfg['paypal']['baseUrl'] ?? 'https://api-m.sandbox.paypal.com';
 
 if (!$clientId || !$secret) {
     http_response_code(500);
@@ -90,7 +92,7 @@ function captureOrder($token, $baseUrl, $orderId)
 if ($action === 'create' && $_SERVER['REQUEST_METHOD'] === 'POST') {
     $data = json_decode(file_get_contents('php://input'), true);
     $amount = $data['amount'] ?? '100.00';
-    $currency = $data['currency'] ?? 'USD';
+    $currency = $data['currency'] ?? ($cfg['paypal']['currency'] ?? 'USD');
     $token = getAccessToken($clientId, $secret, $baseUrl);
     if (!$token) {
         http_response_code(500);

--- a/config.html
+++ b/config.html
@@ -84,6 +84,14 @@
                 <input type="text" id="paypalClientId" class="border rounded px-2 py-1 w-full">
             </label>
             <label class="block">
+                <span class="block mb-1">PayPal Secret</span>
+                <input type="password" id="paypalSecret" class="border rounded px-2 py-1 w-full">
+            </label>
+            <label class="block">
+                <span class="block mb-1">Adres API PayPal</span>
+                <input type="text" id="paypalBaseUrl" class="border rounded px-2 py-1 w-full">
+            </label>
+            <label class="block">
                 <span class="block mb-1">Waluta PayPal</span>
                 <input type="text" id="paypalCurrency" class="border rounded px-2 py-1 w-full">
             </label>
@@ -122,6 +130,8 @@
         const cfg = await fetch('config.json').then(r => r.json()).catch(() => ({}));
         document.getElementById('debugVisible').checked = cfg.debugBoxVisible !== false;
         document.getElementById('paypalClientId').value = cfg.paypal?.clientId || '';
+        document.getElementById('paypalSecret').value = cfg.paypal?.secret || '';
+        document.getElementById('paypalBaseUrl').value = cfg.paypal?.baseUrl || '';
         document.getElementById('paypalCurrency').value = cfg.paypal?.currency || '';
         const mt = cfg.meetingTypes || {};
         Object.entries(mt).forEach(([k, v]) => addMeeting(k, v));
@@ -161,6 +171,8 @@
             debugBoxVisible: document.getElementById('debugVisible').checked,
             paypal: {
                 clientId: document.getElementById('paypalClientId').value.trim(),
+                secret: document.getElementById('paypalSecret').value.trim(),
+                baseUrl: document.getElementById('paypalBaseUrl').value.trim(),
                 currency: document.getElementById('paypalCurrency').value.trim()
             },
             meetingTypes: mt

--- a/config.json
+++ b/config.json
@@ -2,6 +2,8 @@
     "debugBoxVisible": false,
     "paypal": {
         "clientId": "sb",
+        "secret": "",
+        "baseUrl": "https://api-m.sandbox.paypal.com",
         "currency": "PLN"
     },
     "meetingTypes": {


### PR DESCRIPTION
## Summary
- allow editing PayPal secret and API base URL from `config.html`
- store those settings in `config.json`
- read PayPal credentials from `config.json` in backend

## Testing
- `php -l backend/paypal.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867c3c7806883219076d71ef8958c40