### PR TITLE
Integrate Przelewy24 payments

### DIFF
--- a/backend/p24_init.php
+++ b/backend/p24_init.php
@@ -1,0 +1,69 @@
+<?php
+header('Content-Type: application/json');
+$payload = json_decode(file_get_contents('php://input'), true);
+if (!$payload) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid JSON']);
+    exit();
+}
+
+$configPath = dirname(__DIR__) . '/config.json';
+$cfg = file_exists($configPath) ? json_decode(file_get_contents($configPath), true) : [];
+$p24 = $cfg['przelewy24'] ?? [];
+$merchantId = $p24['merchantId'] ?? '';
+$posId = $p24['posId'] ?? $merchantId;
+$crc = $p24['crc'] ?? '';
+$sandbox = isset($p24['sandbox']) ? $p24['sandbox'] : true;
+
+if (!$merchantId || !$posId || !$crc) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Przelewy24 not configured']);
+    exit();
+}
+
+$sessionId = uniqid('p24_', true);
+$amountGrosz = intval($payload['amount']) * 100;
+$description = $payload['meetingType'] . ' ' . ($payload['date'] ?? '') . ' ' . ($payload['time'] ?? '');
+
+$scheme = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? 'https' : 'http';
+$host = $_SERVER['HTTP_HOST'] ?? 'localhost';
+$returnBase = $scheme . '://' . $host . dirname($_SERVER['REQUEST_URI']) . '/p24_return.php';
+
+$request = [
+    'p24_merchant_id' => $merchantId,
+    'p24_pos_id' => $posId,
+    'p24_session_id' => $sessionId,
+    'p24_amount' => $amountGrosz,
+    'p24_currency' => 'PLN',
+    'p24_description' => $description,
+    'p24_email' => $payload['email'] ?? '',
+    'p24_country' => 'PL',
+    'p24_url_return' => $returnBase . '?session=' . urlencode($sessionId),
+    'p24_url_status' => $returnBase . '?session=' . urlencode($sessionId),
+    'p24_sign' => md5($sessionId . '|' . $posId . '|' . $amountGrosz . '|PLN|' . $crc)
+];
+
+$url = $sandbox ? 'https://sandbox.przelewy24.pl/trnRegister' : 'https://secure.przelewy24.pl/trnRegister';
+$ch = curl_init($url);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+curl_setopt($ch, CURLOPT_POST, 1);
+curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($request));
+curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+$response = curl_exec($ch);
+curl_close($ch);
+
+parse_str($response, $resp);
+if (!isset($resp['token']) || ($resp['error'] ?? '1') !== '0') {
+    http_response_code(500);
+    echo json_encode(['error' => 'Register failed', 'details' => $resp]);
+    exit();
+}
+
+// store session details for later verification
+$payload['sessionId'] = $sessionId;
+file_put_contents(__DIR__ . '/p24_sessions/' . $sessionId . '.json', json_encode($payload));
+
+$payUrlBase = $sandbox ? 'https://sandbox.przelewy24.pl/trnRequest/' : 'https://secure.przelewy24.pl/trnRequest/';
+$redirect = $payUrlBase . $resp['token'];
+
+echo json_encode(['url' => $redirect]);

--- a/backend/p24_return.php
+++ b/backend/p24_return.php
@@ -1,0 +1,104 @@
+<?php
+session_start();
+$sessionId = $_GET['session'] ?? $_GET['p24_session_id'] ?? '';
+$orderId = $_GET['p24_order_id'] ?? '';
+
+$configPath = dirname(__DIR__) . '/config.json';
+$cfg = file_exists($configPath) ? json_decode(file_get_contents($configPath), true) : [];
+$p24 = $cfg['przelewy24'] ?? [];
+$merchantId = $p24['merchantId'] ?? '';
+$posId = $p24['posId'] ?? $merchantId;
+$crc = $p24['crc'] ?? '';
+$sandbox = isset($p24['sandbox']) ? $p24['sandbox'] : true;
+
+if (!$sessionId || !$orderId) {
+    echo 'Brak danych zamówienia';
+    exit();
+}
+
+$sessionFile = __DIR__ . '/p24_sessions/' . basename($sessionId) . '.json';
+if (!file_exists($sessionFile)) {
+    echo 'Nie znaleziono danych sesji';
+    exit();
+}
+$data = json_decode(file_get_contents($sessionFile), true);
+$amountGrosz = intval($data['amount']) * 100;
+
+$verify = [
+    'p24_session_id' => $sessionId,
+    'p24_order_id' => $orderId,
+    'p24_amount' => $amountGrosz,
+    'p24_currency' => 'PLN',
+    'p24_sign' => md5($sessionId . '|' . $orderId . '|' . $amountGrosz . '|PLN|' . $crc),
+    'p24_merchant_id' => $merchantId,
+];
+$url = $sandbox ? 'https://sandbox.przelewy24.pl/trnVerify' : 'https://secure.przelewy24.pl/trnVerify';
+$ch = curl_init($url);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+curl_setopt($ch, CURLOPT_POST, 1);
+curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($verify));
+curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+$response = curl_exec($ch);
+curl_close($ch);
+parse_str($response, $resp);
+if (($resp['error'] ?? '1') !== '0') {
+    echo 'Błąd weryfikacji płatności';
+    exit();
+}
+
+// utwórz wydarzenie w kalendarzu
+require_once __DIR__ . '/../vendor/autoload.php';
+use Google\Client;
+use Google\Service\Calendar;
+use Google\Service\Calendar\Event;
+
+$tokenPath = dirname(__DIR__) . '/token.json';
+$client = new Client();
+$client->setAuthConfig(__DIR__ . '/credentials.json');
+$client->addScope(Calendar::CALENDAR);
+$client->setAccessType('offline');
+if (file_exists($tokenPath)) {
+    $client->setAccessToken(json_decode(file_get_contents($tokenPath), true));
+    if ($client->isAccessTokenExpired()) {
+        if ($client->getRefreshToken()) {
+            $client->fetchAccessTokenWithRefreshToken($client->getRefreshToken());
+            file_put_contents($tokenPath, json_encode($client->getAccessToken()));
+        } else {
+            unlink($tokenPath);
+            echo 'Brak tokenu Google';
+            exit();
+        }
+    }
+} else {
+    echo 'Brak tokenu Google';
+    exit();
+}
+$service = new Calendar($client);
+$meetingType = $data['meetingType'];
+$meetingTypes = $cfg['meetingTypes'] ?? [];
+$key = strtolower($meetingType);
+$emoji = $meetingTypes[$key]['emoji'] ?? '🗓️';
+$displayName = $meetingTypes[$key]['name'] ?? ucfirst($meetingType);
+$calendarTitle = $meetingTypes[$key]['calendar_title'] ?? $displayName;
+$summary = trim(sprintf('%s %s%s', $emoji, $calendarTitle, $data['email'] ? ' - ' . $data['email'] : ''));
+
+if (($meetingTypes[$key]['duration'] ?? '') === 'full') {
+    $start = new DateTime($data['date'] . 'T09:00:00');
+    $end = new DateTime($data['date'] . 'T17:00:00');
+} else {
+    $start = new DateTime($data['date'] . 'T' . $data['time'] . ':00');
+    $end = new DateTime($start->format('c'));
+    $minutes = intval($meetingTypes[$key]['duration'] ?? 60);
+    $end->modify('+' . $minutes . ' minutes');
+}
+$event = new Event([
+    'summary' => $summary,
+    'start' => ['dateTime' => $start->format(DateTime::RFC3339)],
+    'end' => ['dateTime' => $end->format(DateTime::RFC3339)],
+    'attendees' => $data['email'] ? [['email' => $data['email']]] : []
+]);
+$service->events->insert('primary', $event);
+
+unlink($sessionFile);
+
+echo 'Płatność zweryfikowana i wydarzenie utworzone. Możesz zamknąć to okno.';

--- a/config.html
+++ b/config.html
@@ -82,6 +82,17 @@
 
         <div id="meetings" class="space-y-4"></div>
 
+        <div id="p24-config" class="border p-4 rounded-md bg-white space-y-2">
+            <h2 class="font-semibold">Przelewy24</h2>
+            <input type="text" id="p24_merchant" class="border rounded px-2 py-1 w-full" placeholder="Merchant ID">
+            <input type="text" id="p24_pos" class="border rounded px-2 py-1 w-full" placeholder="Pos ID">
+            <input type="text" id="p24_crc" class="border rounded px-2 py-1 w-full" placeholder="CRC">
+            <label class="flex items-center space-x-2">
+                <input type="checkbox" id="p24_sandbox" checked>
+                <span>Sandbox</span>
+            </label>
+        </div>
+
         <div class="flex space-x-2">
             <button id="addMeeting" type="button" class="px-4 py-2 bg-blue-500 text-white rounded">Dodaj typ spotkania</button>
             <button id="saveConfig" type="button" class="px-4 py-2 bg-green-600 text-white rounded">Zapisz</button>
@@ -114,6 +125,11 @@
         document.getElementById('debugVisible').checked = cfg.debugBoxVisible !== false;
         const mt = cfg.meetingTypes || {};
         Object.entries(mt).forEach(([k, v]) => addMeeting(k, v));
+        const p24 = cfg.przelewy24 || {};
+        document.getElementById('p24_merchant').value = p24.merchantId || '';
+        document.getElementById('p24_pos').value = p24.posId || '';
+        document.getElementById('p24_crc').value = p24.crc || '';
+        document.getElementById('p24_sandbox').checked = p24.sandbox !== false;
     }
 
     function addMeeting(key = '', data = {}) {
@@ -148,7 +164,13 @@
         });
         const cfg = {
             debugBoxVisible: document.getElementById('debugVisible').checked,
-            meetingTypes: mt
+            meetingTypes: mt,
+            przelewy24: {
+                merchantId: document.getElementById('p24_merchant').value.trim(),
+                posId: document.getElementById('p24_pos').value.trim(),
+                crc: document.getElementById('p24_crc').value.trim(),
+                sandbox: document.getElementById('p24_sandbox').checked
+            }
         };
         const res = await fetch('backend/save_config.php', {
             method: 'POST',

--- a/config.json
+++ b/config.json
@@ -1,50 +1,56 @@
 {
-    "debugBoxVisible": false,
-    "meetingTypes": {
-        "onboarding": {
-            "name": "Onboarding",
-            "calendar_title": "Onboarding",
-            "emoji": "🎉",
-            "duration": "15",
-            "amount": "",
-            "description": "Krótka, 15minutowa sesja, podczas której omówimy zasady współpracy lub przedyskutujemy ustalony temat.",
-            "paid": false
-        },
-        "sesja umówiona": {
-            "name": "Sesja umówiona",
-            "calendar_title": "Sesja umówiona",
-            "emoji": "🤝",
-            "duration": "60",
-            "amount": "",
-            "description": "Jeśli jesteś w procesie współpracy ze mną, wybierz tę opcję - i pracujemy! :)",
-            "paid": false
-        },
-        "kup sesję": {
-            "name": "Kup sesję",
-            "calendar_title": "Sesja płatna",
-            "emoji": "💸",
-            "duration": "60",
-            "amount": "1375",
-            "description": "Jeśli chcesz od razu rozpocząć współpracę, wybierz tą opcję. System poprosi Cię o opłatę przed rezerwacją terminu.",
-            "paid": true
-        },
-        "full day": {
-            "name": "Full day",
-            "calendar_title": "Full day",
-            "emoji": "📅",
-            "duration": "full",
-            "amount": "",
-            "description": "Jeśli chcesz zarezerwować termin całodniowy (warsztaty, przemówienie...), wybierz tę opcję, zarezerwuj termin i skontaktuj się ze mną.",
-            "paid": false
-        },
-        "Warsztaty online": {
-            "name": "Warsztaty online",
-            "calendar_title": "Warsztaty online",
-            "emoji": "",
-            "duration": "90",
-            "amount": "1",
-            "description": "Warsztaty online trwają 4h. Jeśli je u mnie kupiłeś, rezerwuj termin!",
-            "paid": true
-        }
+  "debugBoxVisible": false,
+  "meetingTypes": {
+    "onboarding": {
+      "name": "Onboarding",
+      "calendar_title": "Onboarding",
+      "emoji": "🎉",
+      "duration": "15",
+      "amount": "",
+      "description": "Krótka, 15minutowa sesja, podczas której omówimy zasady współpracy lub przedyskutujemy ustalony temat.",
+      "paid": false
+    },
+    "sesja umówiona": {
+      "name": "Sesja umówiona",
+      "calendar_title": "Sesja umówiona",
+      "emoji": "🤝",
+      "duration": "60",
+      "amount": "",
+      "description": "Jeśli jesteś w procesie współpracy ze mną, wybierz tę opcję - i pracujemy! :)",
+      "paid": false
+    },
+    "kup sesję": {
+      "name": "Kup sesję",
+      "calendar_title": "Sesja płatna",
+      "emoji": "💸",
+      "duration": "60",
+      "amount": "1375",
+      "description": "Jeśli chcesz od razu rozpocząć współpracę, wybierz tą opcję. System poprosi Cię o opłatę przed rezerwacją terminu.",
+      "paid": true
+    },
+    "full day": {
+      "name": "Full day",
+      "calendar_title": "Full day",
+      "emoji": "📅",
+      "duration": "full",
+      "amount": "",
+      "description": "Jeśli chcesz zarezerwować termin całodniowy (warsztaty, przemówienie...), wybierz tę opcję, zarezerwuj termin i skontaktuj się ze mną.",
+      "paid": false
+    },
+    "Warsztaty online": {
+      "name": "Warsztaty online",
+      "calendar_title": "Warsztaty online",
+      "emoji": "",
+      "duration": "90",
+      "amount": "1",
+      "description": "Warsztaty online trwają 4h. Jeśli je u mnie kupiłeś, rezerwuj termin!",
+      "paid": true
     }
+  },
+  "przelewy24": {
+    "merchantId": "",
+    "posId": "",
+    "crc": "",
+    "sandbox": true
+  }
 }

--- a/sesja.html
+++ b/sesja.html
@@ -223,6 +223,7 @@
             const config = await fetch('config.json').then(r => r.json()).catch(() => ({}));
             const debugVisible = config.debugBoxVisible !== false;
             const meetingTypesCfg = config.meetingTypes || {};
+            const p24cfg = config.przelewy24 || {};
 
 
             const select = document.querySelector('select');
@@ -547,8 +548,28 @@
                 const successMsg = `Rezerwacja przyjęta:\n🗓️ Data: ${selectedDate}\n🕒 Godzina: ${selectedTime}\n📧 Email: ${email}\n📌 Typ: ${meetingType}`;
 
                 async function finalize() {
-                    await createCalendarEvent(email, meetingType);
-                    alert(successMsg);
+                    if (mtConf.paid) {
+                        const payload = {
+                            email,
+                            meetingType,
+                            date: selectedDate,
+                            time: selectedTime,
+                            amount: mtConf.amount
+                        };
+                        const resp = await apiRequest('backend/p24_init.php', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify(payload)
+                        });
+                        if (resp && resp.url) {
+                            window.location.href = resp.url;
+                        } else {
+                            alert('Błąd inicjowania płatności');
+                        }
+                    } else {
+                        await createCalendarEvent(email, meetingType);
+                        alert(successMsg);
+                    }
                 }
 
                 await finalize();


### PR DESCRIPTION
## Summary
- configure Przelewy24 credentials in `config.html`
- extend `config.json` with `przelewy24` settings
- add payment initialization and return endpoints
- store temporary payment sessions
- trigger payment on paid meeting reservation

## Testing
- `php -l backend/p24_init.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6867d0ede2fc8321a21824384d624287