### PR TITLE
Improve payment error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# zientkowski-pl
+# zientkowski.pl
+
+This repository contains the public website for **Jerzy Zientkowski**.
+
+## Configuration
+
+The site uses `config.json` for runtime settings. To enable Przelewy24 payments you must provide your merchant credentials in this file (or via `config.html`). Without these values payment initialization will fail and meeting reservations will be saved without redirecting to the payment gateway.
+
+1. Open `config.html` in your browser.
+2. Fill in `Merchant ID`, `Pos ID`, `CRC` and adjust the sandbox flag.
+3. Click **Zapisz** to update `config.json`.
+
+After configuration the `Warsztaty online` option will redirect to Przelewy24 where the payment can be completed.
+

--- a/sesja.html
+++ b/sesja.html
@@ -564,7 +564,10 @@
                         if (resp && resp.url) {
                             window.location.href = resp.url;
                         } else {
-                            alert('Błąd inicjowania płatności');
+                            const msg = resp && resp.error ?
+                                `Błąd inicjowania płatności: ${resp.error}` :
+                                'Błąd inicjowania płatności';
+                            alert(msg);
                         }
                     } else {
                         await createCalendarEvent(email, meetingType);


### PR DESCRIPTION
## Summary
- add missing project setup instructions to README
- expose backend error details when payment initialization fails

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867dacb9560832199b4a960bccba82f