### PR TITLE
Add debug logging for Przelewy24

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,13 @@ The site uses `config.json` for runtime settings. To enable Przelewy24 payments 
 
 After configuration the `Warsztaty online` option will redirect to Przelewy24 where the payment can be completed.
 
+### Debugging payments
+
+To inspect the raw response from the Przelewy24 API enable the "Pokaż debug box"
+option in `config.html`. When a payment request fails the response payload will
+be logged in this box.
+
+Additionally `backend/p24_init.php` appends each response from Przelewy24 to the
+file `backend/p24_debug.log`. Check this file on the server for low level
+details.
+

--- a/backend/p24_init.php
+++ b/backend/p24_init.php
@@ -49,8 +49,21 @@ curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 curl_setopt($ch, CURLOPT_POST, 1);
 curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($request));
 curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+
 $response = curl_exec($ch);
+$curlError = curl_error($ch);
+$httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 curl_close($ch);
+
+// save raw response for debugging
+$logLine = sprintf(
+    "%s HTTP %s CURL:%s RESPONSE:%s\n",
+    date('c'),
+    $httpCode,
+    $curlError ?: 'OK',
+    trim($response)
+);
+file_put_contents(__DIR__ . '/p24_debug.log', $logLine, FILE_APPEND);
 
 parse_str($response, $resp);
 if (!isset($resp['token']) || ($resp['error'] ?? '1') !== '0') {

--- a/sesja.html
+++ b/sesja.html
@@ -567,6 +567,7 @@
                             const msg = resp && resp.error ?
                                 `Błąd inicjowania płatności: ${resp.error}` :
                                 'Błąd inicjowania płatności';
+                            logDebug(`P24 response: ${JSON.stringify(resp)}`);
                             alert(msg);
                         }
                     } else {


### PR DESCRIPTION
## Summary
- log responses from Przelewy24 in `backend/p24_init.php`
- show failed payment responses in the debug box on `sesja.html`
- document debugging options in README

## Testing
- `composer validate --no-check-all` *(fails: command not found)*
- `php -l backend/p24_init.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867ded37b408321829263f12c80dfae