### PR TITLE
Add WTL payment integration test page

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,14 @@ This repository contains the public website for **Jerzy Zientkowski**.
 The site uses `config.json` for runtime settings. Open `config.html` in your
 browser to edit the available meeting types and toggle the debug box.
 
+
+## WTL payment testing
+
+The page `wtl_payment.html` embeds the payment widget provided by WTL. Two
+simple webhook endpoints are available for debugging:
+
+- `backend/wtl_before.php` &ndash; called before payment.
+- `backend/wtl_after.php` &ndash; called after payment.
+
+Both scripts append the received payload to `wtl_before.log` or
+`wtl_after.log` respectively.

--- a/backend/wtl_after.php
+++ b/backend/wtl_after.php
@@ -1,0 +1,7 @@
+<?php
+// Webhook called by WTL after payment is completed
+$log = __DIR__ . '/../wtl_after.log';
+$payload = file_get_contents('php://input');
+file_put_contents($log, date('c') . " " . $payload . "\n", FILE_APPEND);
+header('Content-Type: text/plain');
+echo "ok";

--- a/backend/wtl_before.php
+++ b/backend/wtl_before.php
@@ -1,0 +1,7 @@
+<?php
+// Webhook called by WTL before payment is processed
+$log = __DIR__ . '/../wtl_before.log';
+$payload = file_get_contents('php://input');
+file_put_contents($log, date('c') . " " . $payload . "\n", FILE_APPEND);
+header('Content-Type: text/plain');
+echo "ok";

--- a/wtl_payment.html
+++ b/wtl_payment.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8">
+  <title>WTL Payment Test</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-6">
+  <h1 class="text-2xl font-bold mb-4">Test płatności WTL</h1>
+  <p class="mb-4">Poniższa ramka ładuje formularz płatności z WTL. Webhooki
+  <code>wtl_before.php</code> i <code>wtl_after.php</code> zapisują
+  odebrane dane do plików <code>wtl_before.log</code> oraz <code>wtl_after.log</code>.</p>
+  <style>
+  .wtl-responsive-iframe {
+    width: 1px;
+    min-width: 100%;
+  }
+  </style>
+  <script src="https://kotryszientkowski.elms.pl/assets/js/iframe-resizer-embed.js"></script>
+  <iframe class="wtl-responsive-iframe" src="https://kotryszientkowski.elms.pl/assets/js/s.php?id=1f0e3dad99908345f7439f8ffabdffc4" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <script>
+    iFrameResize({ log: false }, ".wtl-responsive-iframe");
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add sample WTL webhook handlers
- add demo page with WTL payment iframe
- document WTL test page and webhooks in README

## Testing
- `php -v` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_686802e12f988321930675cc6241fe84