### PR TITLE
Add return page for WTL payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,9 @@ simple webhook endpoints are available for debugging:
 
 Both scripts append the received payload to `wtl_before.log` or
 `wtl_after.log` respectively.
+
+The script `wtl_return.php` handles the user return after payment. Configure the
+return URL in the WTL widget to point to this file (e.g.
+`https://yourdomain.com/wtl_return.php`). It displays a simple message based on
+parameters provided by WTL so the customer can see whether the payment was
+successful.

--- a/wtl_payment.html
+++ b/wtl_payment.html
@@ -9,7 +9,10 @@
   <h1 class="text-2xl font-bold mb-4">Test płatności WTL</h1>
   <p class="mb-4">Poniższa ramka ładuje formularz płatności z WTL. Webhooki
   <code>wtl_before.php</code> i <code>wtl_after.php</code> zapisują
-  odebrane dane do plików <code>wtl_before.log</code> oraz <code>wtl_after.log</code>.</p>
+  odebrane dane do plików <code>wtl_before.log</code> oraz <code>wtl_after.log</code>.
+  W ustawieniach WTL można wskazać adres powrotu, np.
+  <code>/wtl_return.php</code>, by po zakończeniu płatności klient zobaczył
+  potwierdzenie.</p>
   <style>
   .wtl-responsive-iframe {
     width: 1px;

--- a/wtl_return.php
+++ b/wtl_return.php
@@ -1,0 +1,28 @@
+<?php
+$log = __DIR__ . '/wtl_return.log';
+file_put_contents($log, date('c') . " " . json_encode($_GET) . "\n", FILE_APPEND);
+$status = $_GET['status'] ?? $_GET['result'] ?? $_GET['success'] ?? '';
+$success = in_array(strtolower($status), ['ok','success','1','true','paid']);
+?>
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8">
+  <title>Wynik płatności</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-6">
+  <h1 class="text-2xl font-bold mb-4">Wynik płatności</h1>
+<?php if ($status === ''): ?>
+  <p>Nie udało się zweryfikować statusu transakcji.</p>
+<?php elseif ($success): ?>
+  <p class="text-green-600">Dziękujemy, płatność została przyjęta.</p>
+<?php else: ?>
+  <p class="text-red-600">Niestety płatność nie powiodła się.</p>
+<?php endif; ?>
+<?php if (!empty($_GET)): ?>
+  <h2 class="font-semibold mt-4">Odebrane parametry</h2>
+  <pre class="bg-gray-100 p-2"><?php echo htmlspecialchars(json_encode($_GET, JSON_PRETTY_PRINT)); ?></pre>
+<?php endif; ?>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- log and display WTL payment status
- document how to configure return URL
- mention return URL in the test payment page

## Testing
- `php -l wtl_return.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868097f49d083218ada203639193fbf