### PR TITLE
Implement daily working hours configuration

### DIFF
--- a/config.html
+++ b/config.html
@@ -81,6 +81,34 @@
             <span>Pokaż debug box</span>
         </label>
 
+        <div id="working-hours" class="space-y-2">
+            <h2 class="text-xl font-bold mt-4">Godziny pracy</h2>
+            <div class="flex items-center space-x-2" data-day="mon">
+                <span class="w-24">Poniedziałek</span>
+                <input type="time" class="wh-start border rounded px-2 py-1">
+                <input type="time" class="wh-end border rounded px-2 py-1">
+            </div>
+            <div class="flex items-center space-x-2" data-day="tue">
+                <span class="w-24">Wtorek</span>
+                <input type="time" class="wh-start border rounded px-2 py-1">
+                <input type="time" class="wh-end border rounded px-2 py-1">
+            </div>
+            <div class="flex items-center space-x-2" data-day="wed">
+                <span class="w-24">Środa</span>
+                <input type="time" class="wh-start border rounded px-2 py-1">
+                <input type="time" class="wh-end border rounded px-2 py-1">
+            </div>
+            <div class="flex items-center space-x-2" data-day="thu">
+                <span class="w-24">Czwartek</span>
+                <input type="time" class="wh-start border rounded px-2 py-1">
+                <input type="time" class="wh-end border rounded px-2 py-1">
+            </div>
+            <div class="flex items-center space-x-2" data-day="fri">
+                <span class="w-24">Piątek</span>
+                <input type="time" class="wh-start border rounded px-2 py-1">
+                <input type="time" class="wh-end border rounded px-2 py-1">
+            </div>
+        </div>
 
 
         <div id="meetings" class="space-y-4"></div>
@@ -116,6 +144,14 @@
     async function loadConfig() {
         const cfg = await fetch('config.json').then(r => r.json()).catch(() => ({}));
         document.getElementById('debugVisible').checked = cfg.debugBoxVisible !== false;
+
+        const wh = cfg.workingHours || {};
+        document.querySelectorAll('#working-hours [data-day]').forEach(row => {
+            const day = row.getAttribute('data-day');
+            row.querySelector('.wh-start').value = wh[day]?.start || '';
+            row.querySelector('.wh-end').value = wh[day]?.end || '';
+        });
+
         const mt = cfg.meetingTypes || {};
         Object.entries(mt).forEach(([k, v]) => addMeeting(k, v));
     }
@@ -150,8 +186,18 @@
                 paid: el.querySelector('.paid').checked
             };
         });
+        const wh = {};
+        document.querySelectorAll('#working-hours [data-day]').forEach(row => {
+            const day = row.getAttribute('data-day');
+            wh[day] = {
+                start: row.querySelector('.wh-start').value,
+                end: row.querySelector('.wh-end').value
+            };
+        });
+
         const cfg = {
             debugBoxVisible: document.getElementById('debugVisible').checked,
+            workingHours: wh,
             meetingTypes: mt,
         };
         const res = await fetch('backend/save_config.php', {

--- a/config.json
+++ b/config.json
@@ -1,5 +1,14 @@
 {
   "debugBoxVisible": false,
+  "workingHours": {
+    "mon": { "start": "09:00", "end": "17:00" },
+    "tue": { "start": "09:00", "end": "17:00" },
+    "wed": { "start": "09:00", "end": "17:00" },
+    "thu": { "start": "09:00", "end": "17:00" },
+    "fri": { "start": "09:00", "end": "17:00" },
+    "sat": { "start": "09:00", "end": "17:00" },
+    "sun": { "start": "09:00", "end": "17:00" }
+  },
   "meetingTypes": {
     "onboarding": {
       "name": "Onboarding",

--- a/sesja.html
+++ b/sesja.html
@@ -226,6 +226,7 @@
             const config = await fetch('config.json').then(r => r.json()).catch(() => ({}));
             const debugVisible = config.debugBoxVisible !== false;
             const meetingTypesCfg = config.meetingTypes || {};
+            const workingHoursCfg = config.workingHours || {};
 
 
             const select = document.querySelector('select');
@@ -477,6 +478,11 @@
                 timeButtons.innerHTML = "";
                 
 
+                const dayKey = ['sun','mon','tue','wed','thu','fri','sat'][parsed.getDay()];
+                const whDay = workingHoursCfg[dayKey] || {};
+                const whStart = whDay.start || '09:00';
+                const whEnd = whDay.end || '17:00';
+
                 if (mtConf.duration === 'full') {
                     timeLabel.textContent = `Sprawdź dostępność (${dateLabel})`;
                     if (busySlots.length === 0) {
@@ -485,7 +491,7 @@
                         fullBtn.textContent = "Full day";
                         fullBtn.className = "border rounded px-3 py-2 text-sm transition hover:bg-accent hover:text-white";
                         fullBtn.addEventListener("click", () => {
-                            selectedTime = "09:00";
+                            selectedTime = whStart;
                             [...timeButtons.children].forEach(b => b.classList.remove("bg-accent", "text-white"));
                             fullBtn.classList.add("bg-accent", "text-white");
                         });
@@ -502,9 +508,9 @@
                 timeLabel.textContent = `Wybierz godzinę (${dateLabel})`;
 
                 const slots = [];
-                let cursor = new Date(`${selectedDate}T09:00:00`);
-                const dayEnd = new Date(`${selectedDate}T17:00:00`);
-                while (cursor < dayEnd) {
+                let cursor = new Date(`${selectedDate}T${whStart}:00`);
+                const dayEnd = new Date(`${selectedDate}T${whEnd}:00`);
+                while (cursor.getTime() + duration * 60000 <= dayEnd.getTime()) {
                     const time = cursor.toLocaleTimeString('pl-PL', { hour: '2-digit', minute: '2-digit', hour12: false });
                     slots.push(time);
                     cursor.setMinutes(cursor.getMinutes() + duration);
@@ -558,8 +564,12 @@
                 let endDateTime;
                 const mtConf = meetingTypesCfg[meetingType] || {};
                 if (mtConf.duration === 'full') {
-                    startDateTime = new Date(`${selectedDate}T09:00:00`);
-                    endDateTime = new Date(`${selectedDate}T17:00:00`);
+                    const dayKey = ['sun','mon','tue','wed','thu','fri','sat'][new Date(selectedDate).getDay()];
+                    const whDay = workingHoursCfg[dayKey] || {};
+                    const whStart = whDay.start || '09:00';
+                    const whEnd = whDay.end || '17:00';
+                    startDateTime = new Date(`${selectedDate}T${whStart}:00`);
+                    endDateTime = new Date(`${selectedDate}T${whEnd}:00`);
                 } else {
                     startDateTime = new Date(`${selectedDate}T${selectedTime}:00`);
                     endDateTime = new Date(startDateTime);


### PR DESCRIPTION
## Summary
- allow editing working hours in config.html
- store workingHours in config.json
- use working hours when listing time slots and creating events
- limit calendar busy query to configured end hours

## Testing
- `php -l backend/calendar.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bbe3f09488321b1ae04fb3b0bcd88