### PR TITLE
Handle payment status before booking

### DIFF
--- a/sesja.html
+++ b/sesja.html
@@ -311,6 +311,13 @@
             function showPaymentIframe(onClose) {
                 const modal = document.getElementById('payment-modal');
                 const closeBtn = document.getElementById('payment-close');
+                let paymentOk = false;
+                const msgHandler = (e) => {
+                    if (e.data && e.data.wtlPaymentStatus) {
+                        paymentOk = e.data.wtlPaymentStatus === 'success';
+                    }
+                };
+                window.addEventListener('message', msgHandler);
                 modal.classList.remove('hidden');
                 iFrameResize({ log: false }, '#payment-frame');
                 fetchWebhookLogs();
@@ -318,8 +325,13 @@
                 const handler = () => {
                     modal.classList.add('hidden');
                     clearInterval(pollInterval);
+                    window.removeEventListener('message', msgHandler);
                     closeBtn.removeEventListener('click', handler);
-                    if (onClose) onClose();
+                    if (paymentOk) {
+                        if (onClose) onClose();
+                    } else {
+                        alert('Płatność nie została potwierdzona, rezerwacja nie została zapisana.');
+                    }
                 };
                 closeBtn.addEventListener('click', handler);
             }

--- a/wtl_return.php
+++ b/wtl_return.php
@@ -24,5 +24,8 @@ $success = in_array(strtolower($status), ['ok','success','1','true','paid']);
   <h2 class="font-semibold mt-4">Odebrane parametry</h2>
   <pre class="bg-gray-100 p-2"><?php echo htmlspecialchars(json_encode($_GET, JSON_PRETTY_PRINT)); ?></pre>
 <?php endif; ?>
+  <script>
+    window.parent.postMessage({ wtlPaymentStatus: <?php echo $success ? "'success'" : "'fail'"; ?> }, '*');
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- prevent booking if payment status isn't confirmed
- send payment status from `wtl_return.php`

## Testing
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fd51be61c8321ae0cbb478d677b48