### PR TITLE
Fix paid booking flow

### DIFF
--- a/sesja.html
+++ b/sesja.html
@@ -312,9 +312,21 @@
                 const modal = document.getElementById('payment-modal');
                 const closeBtn = document.getElementById('payment-close');
                 let paymentOk = false;
+                let handler;
+                const cleanup = () => {
+                    modal.classList.add('hidden');
+                    clearInterval(pollInterval);
+                    window.removeEventListener('message', msgHandler);
+                    if (handler) closeBtn.removeEventListener('click', handler);
+                };
+                const finalize = () => {
+                    cleanup();
+                    if (onClose) onClose();
+                };
                 const msgHandler = (e) => {
                     if (e.data && e.data.wtlPaymentStatus) {
                         paymentOk = e.data.wtlPaymentStatus === 'success';
+                        if (paymentOk) finalize();
                     }
                 };
                 window.addEventListener('message', msgHandler);
@@ -322,11 +334,8 @@
                 iFrameResize({ log: false }, '#payment-frame');
                 fetchWebhookLogs();
                 pollInterval = setInterval(fetchWebhookLogs, 2000);
-                const handler = () => {
-                    modal.classList.add('hidden');
-                    clearInterval(pollInterval);
-                    window.removeEventListener('message', msgHandler);
-                    closeBtn.removeEventListener('click', handler);
+                handler = () => {
+                    cleanup();
                     if (paymentOk) {
                         if (onClose) onClose();
                     } else {

--- a/wtl_return.php
+++ b/wtl_return.php
@@ -3,6 +3,10 @@ $log = __DIR__ . '/wtl_return.log';
 file_put_contents($log, date('c') . " " . json_encode($_GET) . "\n", FILE_APPEND);
 $status = $_GET['status'] ?? $_GET['result'] ?? $_GET['success'] ?? '';
 $success = in_array(strtolower($status), ['ok','success','1','true','paid']);
+// Treat missing status as success because WTL may not provide it
+if ($status === '' && !empty($_GET['wtl_offer_uid'])) {
+    $success = true;
+}
 ?>
 <!DOCTYPE html>
 <html lang="pl">
@@ -13,10 +17,10 @@ $success = in_array(strtolower($status), ['ok','success','1','true','paid']);
 </head>
 <body class="p-6">
   <h1 class="text-2xl font-bold mb-4">Wynik płatności</h1>
-<?php if ($status === ''): ?>
+<?php if ($success): ?>
+  <p class="text-green-600">Dziękujemy za rezerwację terminu.</p>
+<?php elseif ($status === ''): ?>
   <p>Nie udało się zweryfikować statusu transakcji.</p>
-<?php elseif ($success): ?>
-  <p class="text-green-600">Dziękujemy, płatność została przyjęta.</p>
 <?php else: ?>
   <p class="text-red-600">Niestety płatność nie powiodła się.</p>
 <?php endif; ?>


### PR DESCRIPTION
## Summary
- finalize reservation after paid checkout
- treat missing status in `wtl_return.php` as success and show booking thank you page
- auto finalize booking when payment succeeds in `sesja.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68727ee1b0f08321b6a94d33fe0d102c